### PR TITLE
update scikit-learn version

### DIFF
--- a/mlops/step-functions-data-science-sdk/model-train-evaluate-compare/step_functions_mlworkflow_scikit_learn_data_processing_and_model_evaluation_with_experiments.ipynb
+++ b/mlops/step-functions-data-science-sdk/model-train-evaluate-compare/step_functions_mlworkflow_scikit_learn_data_processing_and_model_evaluation_with_experiments.ipynb
@@ -127,7 +127,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "jp-MarkdownHeadingCollapsed": true,
+    "tags": []
+   },
    "source": [
     "次に、ノートブックから Step Functions を実行するための IAM ロール設定を行います。\n",
     "\n",
@@ -221,6 +224,7 @@
     "                \"glue:GetJobRuns\",\n",
     "                \"glue:StartJobRun\",\n",
     "                \"lambda:InvokeFunction\",\n",
+    "                \"sagemaker:AddTags\",\n",
     "                \"sagemaker:CreateEndpoint\",\n",
     "                \"sagemaker:CreateEndpointConfig\",\n",
     "                \"sagemaker:CreateHyperParameterTuningJob\",\n",
@@ -404,7 +408,7 @@
    "outputs": [],
    "source": [
     "sklearn_processor = SKLearnProcessor(\n",
-    "    framework_version=\"0.20.0\",\n",
+    "    framework_version=\"0.23-1\",\n",
     "    role=role,\n",
     "    instance_type=\"ml.m5.xlarge\",\n",
     "    instance_count=1,\n",
@@ -506,16 +510,16 @@
     "\n",
     "    preprocess = make_column_transformer(\n",
     "        (\n",
-    "            [\"age\", \"num persons worked for employer\"],\n",
     "            KBinsDiscretizer(encode=\"onehot-dense\", n_bins=10),\n",
+    "            [\"age\", \"num persons worked for employer\"],\n",
     "        ),\n",
     "        (\n",
-    "            [\"capital gains\", \"capital losses\", \"dividends from stocks\"],\n",
     "            StandardScaler(),\n",
+    "            [\"capital gains\", \"capital losses\", \"dividends from stocks\"],\n",
     "        ),\n",
     "        (\n",
-    "            [\"education\", \"major industry code\", \"class of worker\"],\n",
     "            OneHotEncoder(sparse=False),\n",
+    "            [\"education\", \"major industry code\", \"class of worker\"],\n",
     "        ),\n",
     "    )\n",
     "    print(\"Running preprocessing and feature engineering transformations\")\n",
@@ -628,7 +632,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "\n",
     "processing_step = ProcessingStep(\n",
     "    \"SageMaker pre-processing step\",\n",
     "    processor=sklearn_processor,\n",
@@ -661,7 +664,7 @@
     "    entry_point=\"train.py\",\n",
     "    train_instance_type=\"ml.m5.xlarge\",\n",
     "    role=role,\n",
-    "    framework_version=\"0.20.0\",\n",
+    "    framework_version=\"0.23-1\",\n",
     "    py_version=\"py3\",\n",
     ")"
    ]
@@ -686,7 +689,7 @@
     "\n",
     "import pandas as pd\n",
     "from sklearn.linear_model import LogisticRegression\n",
-    "from sklearn.externals import joblib\n",
+    "import joblib\n",
     "\n",
     "if __name__ == \"__main__\":\n",
     "    \n",
@@ -786,7 +789,7 @@
     "\n",
     "import pandas as pd\n",
     "\n",
-    "from sklearn.externals import joblib\n",
+    "import joblib\n",
     "from sklearn.metrics import classification_report, roc_auc_score, accuracy_score\n",
     "\n",
     "from smexperiments.tracker import Tracker\n",
@@ -952,7 +955,7 @@
     "ENV AWS_DEFAULT_REGION {region}\n",
     "\n",
     "RUN pip3 install --upgrade pip\n",
-    "RUN pip3 install -qU boto3 pandas==0.25.3 scikit-learn==0.20.0 sagemaker-experiments==0.1.35 sagemaker==2.60.0 torch==1.8.0 torchvision==0.9.0\n",
+    "RUN pip3 install -qU boto3 pandas==0.25.3 scikit-learn==0.23.1 sagemaker-experiments==0.1.35 sagemaker==2.109.0\n",
     "\n",
     "ENTRYPOINT [\"python3\", \"/opt/ml/processing/input/code/evaluation.py\"]\n",
     "\"\"\"\n",
@@ -1917,7 +1920,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.13"
+   "version": "3.8.12"
   },
   "toc": {
    "base_numbering": 1,


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Step Functionsのサンプルが動かなくなっていたのでScikit-Learnのバージョンを0.20.0から0.23.1に上げたり、それに合わせて一部コードの修正をおこなっています。
また、sagemaker:AddTagsの権限がないというエラーも出ていたのでStep Functionsに付与するポリシーを追加しました。

動作検証はSageMaker Notebook instanceのml.t3.xlarge、Amazon Linux 2、JupyterLab 3、conda python 3カーネルで行いました。

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
