### PR TITLE
Fix set_peft_model_state_dict in finetune.py

### DIFF
--- a/tasks/generative-ai/text-to-text/fine-tuning/instruction-tuning/Transformers/scripts/code/finetune.py
+++ b/tasks/generative-ai/text-to-text/fine-tuning/instruction-tuning/Transformers/scripts/code/finetune.py
@@ -256,7 +256,7 @@ def train(
         if os.path.exists(checkpoint_name):
             print(f"Restarting from {checkpoint_name}")
             adapters_weights = torch.load(checkpoint_name)
-            model = set_peft_model_state_dict(model, adapters_weights)
+            set_peft_model_state_dict(model, adapters_weights)
         else:
             print(f"Checkpoint {checkpoint_name} not found")
 


### PR DESCRIPTION
## Issue

The same as https://github.com/tloen/alpaca-lora/issues/316. We have to follow the changes because `set_peft_model_state_dict` now returns `None`.

## Description of changes:

### Before
```python
model = set_peft_model_state_dict(model, adapters_weights)
```

### After
```python
set_peft_model_state_dict(model, adapters_weights)
```