### PR TITLE
IaCコード修正

### DIFF
--- a/sagemaker/sagemaker-studio/IaC/case01/terraform/README.md
+++ b/sagemaker/sagemaker-studio/IaC/case01/terraform/README.md
@@ -2,8 +2,8 @@
 
 ### git clone & cd
 ```
-git clone https://gitlab.aws.dev/kudtomoy/cdk-sagemaker-studio.git
-cd cdk-sagemaker-studio/case01/terraform
+git clone https://github.com/aws-samples/aws-ml-jp.git
+cd aws-ml-jp/sagemaker/sagemaker-studio/IaC/case01/terraform
 ```
 
 ### 鍵保管用のディレクトリ作成

--- a/sagemaker/sagemaker-studio/IaC/case02/cdk-python/chococones/chococones.py
+++ b/sagemaker/sagemaker-studio/IaC/case02/cdk-python/chococones/chococones.py
@@ -255,6 +255,10 @@ class ChococonesStack(Stack):
             vpc=vpc,
             allow_all_outbound=True,
         )
+        domain_security_group.add_ingress_rule(
+            ec2.Peer.ipv4("10.0.0.0/16"),
+            ec2.Port.tcp_range(8192,65535)
+        )
 
         # Studio Domain
         domain = sagemaker.CfnDomain(
@@ -264,13 +268,6 @@ class ChococonesStack(Stack):
             default_user_settings=sagemaker.CfnDomain.UserSettingsProperty(
                 execution_role=default_role.role_arn,
                 security_groups=[domain_security_group.security_group_id],
-                jupyter_server_app_settings=sagemaker.CfnDomain.JupyterServerAppSettingsProperty(
-                    default_resource_spec=sagemaker.CfnDomain.ResourceSpecProperty(
-                        # 以下 ARN は Region ごとに違うので、以下ドキュメントを参照のこと
-                        # https://docs.aws.amazon.com/sagemaker/latest/dg/studio-jl.html
-                        sage_maker_image_arn=f"arn:aws:sagemaker:{REGION}:081325390199:image/jupyter-server-3",
-                    )
-                ),
             ),
             domain_name=DOMAIN_NAME,
             vpc_id=vpc.vpc_id,

--- a/sagemaker/sagemaker-studio/IaC/case02/cdk-typescript/lib/chococones-stack.ts
+++ b/sagemaker/sagemaker-studio/IaC/case02/cdk-typescript/lib/chococones-stack.ts
@@ -203,17 +203,13 @@ export class ChococonesStack extends cdk.Stack {
         allowAllOutbound: true,
       }
     )
+    domainSecurityGroup.addIngressRule(ec2.Peer.ipv4('10.0.0.0/16'), ec2.Port.tcpRange(8192,65535))
     // Studio Domain
     const domain = new sagemaker.CfnDomain(this, 'Domain', {
       authMode: 'IAM',
       defaultUserSettings: {
         executionRole: defaultRole.roleArn,
         securityGroups: [domainSecurityGroup.securityGroupId],
-        jupyterServerAppSettings: {
-          defaultResourceSpec: {
-            sageMakerImageArn: `arn:aws:sagemaker:${this.region}:102112518831:image/jupyter-server-3`,
-          },
-        },
       },
       domainName,
       vpcId: vpc.vpcId,

--- a/sagemaker/sagemaker-studio/IaC/case02/terraform/README.md
+++ b/sagemaker/sagemaker-studio/IaC/case02/terraform/README.md
@@ -2,8 +2,8 @@
 
 ### git clone & cd
 ```
-git clone https://gitlab.aws.dev/kudtomoy/cdk-sagemaker-studio.git
-cd cdk-sagemaker-studio/case01/terraform
+git clone https://github.com/aws-samples/aws-ml-jp.git
+cd aws-ml-jp/sagemaker/sagemaker-studio/IaC/case02/terraform
 ```
 
 ### 鍵保管用のディレクトリ作成

--- a/sagemaker/sagemaker-studio/IaC/case02/terraform/examples/main.tf
+++ b/sagemaker/sagemaker-studio/IaC/case02/terraform/examples/main.tf
@@ -537,6 +537,13 @@ resource "aws_security_group" "sagemaker_studio_outbound" {
   name        = "sagemaker_studio_outbound"
   description = "Sagemaker Studio Doamain sample"
   vpc_id      = module.vpc_for_sagemaker.vpc_id
+  ingress {
+    description      = "tcp access from KernelGateway"
+    from_port        = 8192
+    to_port          = 65535
+    protocol         = "tcp"
+    cidr_blocks      = ["10.0.0.0/16"]
+  }
   egress {
     from_port        = 0
     to_port          = 0
@@ -561,11 +568,6 @@ resource "aws_sagemaker_domain" "domain" {
   default_user_settings {
     execution_role  = aws_iam_role.sagemaker_execution_role_default.arn
     security_groups = [aws_security_group.sagemaker_studio_outbound.id]
-    jupyter_server_app_settings {
-      default_resource_spec {
-        sagemaker_image_arn = "arn:aws:sagemaker:${data.aws_region.current.name}:081325390199:image/jupyter-server-3"
-      }
-    }
   }
 }
 


### PR DESCRIPTION
下記の記事で利用するIaCの修正を行いました
https://aws.amazon.com/jp/builders-flash/202304/kinoko-takenoko-sagemaker-iac/?awsf.filter-name=*all

**修正点**
- Terraformのreadme.txtの誤記を修正
- SagemakerStudio環境作成時のリージョン依存性のある記載を削除
- SagemakerStudio Domainに紐付けるSGにKernelGatewayからのTCP接続許可設定を追加
  - これは、ブログ執筆後に追加された以下の要件への対応です
  - https://docs.aws.amazon.com/ja_jp/sagemaker/latest/dg/studio-notebooks-and-internet-access.html#studio-notebooks-and-internet-access-vpc